### PR TITLE
Fix Rollup semicolon bug in GSS import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+/.idea

--- a/lib/deps.js
+++ b/lib/deps.js
@@ -5,8 +5,11 @@
  */
 
 /* No GSS on Windows. */
-export const GSS = await
-    import("gssapi.js")
+/* `await` and `import` must be on the same line to circumvent
+ * a bug in Rollup where it insists on adding a semicolon after
+ * the `await` keyword.
+ */
+export const GSS = await import("gssapi.js")
         .then(mod => mod.default)
         .catch(e => undefined);
 


### PR DESCRIPTION
The `await` and `import` statements were moved onto the same line in lib/deps.js. This resolves a bug in the Rollup module bundler, which was incorrectly adding a semicolon after the `await` keyword.