### PR TITLE
Implement the new WS notify interface

### DIFF
--- a/lib/deps.js
+++ b/lib/deps.js
@@ -17,6 +17,7 @@ export const GSS = await import("gssapi.js")
  * 'you can't do `export Foo from "foo"`' then maybe you should design
  * the syntax so you can... ? */
 export { default as MQTT } from "mqtt";
+export { default as WebSocket } from "isomorphic-ws";
 
 export async function build_node_fetch () {
   /* We have to go round the houses a bit here... */

--- a/lib/service/configdb-watcher.js
+++ b/lib/service/configdb-watcher.js
@@ -8,11 +8,66 @@
  */
 
 import * as rx from "rxjs";
+import { v4 as uuidv4 } from "uuid";
+
+import * as rxx from "@amrc-factoryplus/rx-util";
+
+import * as UUIDs from "../uuids.js";
+import { ServiceError } from "./service-interface.js";
 
 export class ConfigDBWatcher {
     constructor (configdb, device) {
         this.configdb = configdb;
         this.device = device;
+        
+        this.log = configdb.fplus.debug.bound("cdbwatch");
+
+        this.updates = rxx.rx(
+            rx.defer(() => this.notify()),
+            rx.flatMap(ws => rxx.rx(
+                rx.fromEvent(ws, "message"),
+                rx.takeUntil(rx.fromEvent(ws, "close")))),
+            rx.map(m => JSON.parse(m.data)),
+            rx.tap(u => this.log("UPDATE: %o", u)),
+            rx.share(),
+        );
+    }
+    
+    /* XXX I don't like this way of doing this, the state management is
+     * awful. There must be a better way. */
+    #notify = null;
+    async notify () {
+        if (this.#notify)
+            return this.#notify;
+        this.#notify = await this.configdb.websocket("notify/v2");
+        this.#notify.addEventListener("close", 
+            () => this.#notify = null);
+        return this.#notify;
+    }
+
+    /* This accepts a request structure, without a UUID. When the
+     * returned seq is subscribed to, it generates a new UUID for the
+     * request, sends the request, and returns a sequence of the
+     * responses. */
+    request (req) {
+        return rxx.rx(
+            rx.defer(() => this.notify()),
+            rx.flatMap(ws => {
+                const uuid = uuidv4();
+                const send = data => {
+                    this.log("Sending request %o", data);
+                    ws.send(JSON.stringify(data));
+                };
+                send({ ...req, uuid });
+                return rxx.rx(
+                    this.updates,
+                    rx.finalize(() => send({ method: "CLOSE", uuid })),
+                    rx.filter(u => u.uuid == uuid),
+                    rx.tap(u => u.status < 400 || u.status == 410
+                        || this.log("Notify error: %s", u.status)),
+                    rx.takeWhile(u => u.status < 400),
+                    rx.map(u => u.response));
+            }));
     }
 
     /* For now this returns an Observable<undefined>. It would be much
@@ -29,11 +84,23 @@ export class ConfigDBWatcher {
             rx.map(u => undefined));
     }
 
+    watch_url (url) {
+        return rxx.rx(
+            this.request({ method: "WATCH", request: { url } }),
+            rx.map(upd => {
+                if (upd.status == 200 || upd.status == 201)
+                    return upd.body;
+                if (upd.status == 404)
+                    return null;
+                throw new ServiceError(
+                    UUIDs.Service.ConfigDB,
+                    `Error watching ${url}`,
+                    upd.status);
+            }));
+    }
+
     watch_config (app, obj) {
-        return this.application(app).pipe(
-            rx.startWith(undefined),
-            rx.switchMap(() => this.configdb.get_config(app, obj)),
-        );
+        return this.watch_url(`app/${app}/object/${obj}`);
     }
 
     watch_search (app, query) {

--- a/lib/service/configdb-watcher.js
+++ b/lib/service/configdb-watcher.js
@@ -22,45 +22,64 @@ export class ConfigDBWatcher {
         
         this.log = configdb.fplus.debug.bound("cdbwatch");
 
-        this.updates = rxx.rx(
-            rx.defer(() => this.notify()),
-            rx.flatMap(ws => rxx.rx(
-                rx.fromEvent(ws, "message"),
-                rx.takeUntil(rx.fromEvent(ws, "close")))),
-            rx.map(m => JSON.parse(m.data)),
-            rx.tap(u => this.log("UPDATE: %o", u)),
-            rx.share(),
-        );
-    }
-    
-    /* XXX I don't like this way of doing this, the state management is
-     * awful. There must be a better way. */
-    #notify = null;
-    async notify () {
-        if (this.#notify)
-            return this.#notify;
-        this.#notify = await this.configdb.websocket("notify/v2");
-        this.#notify.addEventListener("close", 
-            () => this.#notify = null);
-        return this.#notify;
+        this.notify = this._build_notify();
     }
 
+    _handle_notify_ws (ws) {
+        const error = rxx.rx(
+            rx.fromEvent(ws, "error"),
+            rx.tap(e => this.log("Notify WS error: %o", e)));
+        const stopped = rx.merge(error, rx.fromEvent(ws, "close"));
+        const msgs = rxx.rx(
+            rx.fromEvent(ws, "message"),
+            rx.map(m => JSON.parse(m.data)),
+            rx.tap(v => this.log("Notify update: %o", v)),
+            rx.share());
+        const send = msg => {
+            if (ws.readyState > ws.constructor.OPEN) {
+                this.log("Ignoring send to closing WS");
+                return;
+            }
+            this.log("Sending request %o", msg);
+            ws.send(JSON.stringify(msg));
+        };
+
+        return rxx.rx(
+            rx.merge(rx.of([send, msgs]), error),
+            rx.finalize(() => {
+                this.log("Closing notify WS");
+                ws.close();
+            }),
+            rx.takeUntil(stopped));
+    }
+
+    _build_notify () {
+        return rxx.rx(
+            rx.defer(() => this.configdb.websocket("notify/v2")),
+            rx.catchError(e => {
+                this.log("Notify WS connect error: %s", e);
+                return rx.EMPTY;
+            }),
+            rx.flatMap(ws => this._handle_notify_ws(ws)),
+            rx.endWith(null),
+            rx.repeat({ delay: () => rx.timer(5000 + Math.random()*2000) }),
+            rx.tap(v => this.log("Notify socket %s", v ? "open" : "closed")),
+            rxx.shareLatest(),
+            rx.filter(w => w));
+    }
+    
     /* This accepts a request structure, without a UUID. When the
      * returned seq is subscribed to, it generates a new UUID for the
      * request, sends the request, and returns a sequence of the
      * responses. */
     request (req) {
         return rxx.rx(
-            rx.defer(() => this.notify()),
-            rx.flatMap(ws => {
+            this.notify,
+            rx.switchMap(([send, updates]) => {
                 const uuid = uuidv4();
-                const send = data => {
-                    this.log("Sending request %o", data);
-                    ws.send(JSON.stringify(data));
-                };
                 send({ ...req, uuid });
                 return rxx.rx(
-                    this.updates,
+                    updates,
                     rx.finalize(() => send({ method: "CLOSE", uuid })),
                     rx.filter(u => u.uuid == uuid),
                     rx.tap(u => u.status < 400 || u.status == 410

--- a/lib/service/fetch.js
+++ b/lib/service/fetch.js
@@ -4,9 +4,9 @@
  * Copyright 2022 AMRC.
  */
 
-import { build_node_fetch, GSS } from "../deps.js";
+import { build_node_fetch, GSS, WebSocket } from "../deps.js";
 
-import { ServiceInterface } from "./service-interface.js";
+import { ServiceError, ServiceInterface } from "./service-interface.js";
 
 const Auth_rx = /^([A-Za-z]+) +([A-Za-z0-9._~+/=-]+)$/;
 
@@ -101,6 +101,58 @@ export default class Fetch extends ServiceInterface {
         }
     }
 
+    async websocket (opts) {
+        const base = opts.service_url
+            ?? await this.fplus.service_url(opts.service);
+        const url = new URL(opts.url, base);
+
+        const ws = new WebSocket(url);
+        await new Promise((resolve, reject) => {
+            const errh = e => {
+                const msg = e.type == "error"
+                    ? `WebSocket connection error: ${e.message}`
+                    : "WebSocket connection failed";
+                /* XXX should supply e as cause here */
+                reject(new ServiceError(opts.service, msg));
+            };
+            ws.addEventListener("open", resolve, { once: true });
+            ws.addEventListener("error", errh, { once: true });
+        });
+        return ws;
+    }
+
+    async ws_with_auth (opts) {
+        const base = await this.fplus.service_url(opts.service);
+
+        const try_ws = async bad => {
+            const ws = await this.websocket({ ...opts, service_url: base });
+            const token = await this.service_token(base, bad);
+
+            ws.send(`Bearer ${token}`);
+            const msg = await new Promise((resolve, reject) => {
+                ws.addEventListener("message", resolve, { once: true });
+                ws.addEventListener("error", reject, { once: true });
+            });
+
+            return [ws, msg.data, token];
+        };
+
+        let [ws, st, bad] = await try_ws();
+        if (st == "401")
+            [ws, st] = await try_ws(bad);
+        if (st == "200")
+            return ws;
+        
+        if (typeof st == "string" && /^[0-9]{3}$/.test(st)) {
+            throw new ServiceError(opts.service,
+                "WebSocket connection refused",
+                Number.parseInt(st, 10));
+        }
+
+        throw new ServiceError(opts.service,
+            "Unrecognised WS auth response: %s", st);
+    }
+        
     async do_fetch (url, opts) {
         let token;
         const try_fetch = async () => {

--- a/lib/service/fetch.js
+++ b/lib/service/fetch.js
@@ -145,7 +145,7 @@ export default class Fetch extends ServiceInterface {
         
         if (typeof st == "string" && /^[0-9]{3}$/.test(st)) {
             throw new ServiceError(opts.service,
-                "WebSocket connection refused",
+                "WebSocket auth refused",
                 Number.parseInt(st, 10));
         }
 

--- a/lib/service/service-interface.js
+++ b/lib/service/service-interface.js
@@ -81,4 +81,12 @@ export class ServiceInterface {
         if (st != 200) return;
         return ping;
     }
+
+    /* This always authenticates the WS */
+    websocket (url) {
+        return this.fplus.Fetch.ws_with_auth({
+            service:    this.service,
+            url,
+        });
+    }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "content-type": "^1.0.5",
+    "isomorphic-ws": "^5.0.0",
     "mqtt": "^5.3.6",
     "optional-js": "^2.3.0",
     "semver": "^7.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amrc-factoryplus/service-client",
-  "version": "1.3.6",
+  "version": "1.3.7-bmz.1",
   "description": "",
   "main": "lib/index.js",
   "type": "module",
@@ -16,7 +16,8 @@
     "mqtt": "^5.3.6",
     "optional-js": "^2.3.0",
     "semver": "^7.6.0",
-    "sparkplug-payload": "^1.0.3"
+    "sparkplug-payload": "^1.0.3",
+    "uuid": "^10.0.0"
   },
   "optionalDependencies": {
     "got-fetch": "^5.1.8",


### PR DESCRIPTION
This is implemented as part of the existing ConfigDBWatcher class, which uses `sparkplug-app` to watch the service over MQTT. The new WS interface will supersede and replace the Sparkplug, so for now no attempt is made to fall back to MQTT. We will need to decide how to handle the compatibility aspects here, especially given that the edge cluster services are currently using the MQTT interface.

The 'notify client' interface will eventually need generalising to cover any service, with ConfigDBWatcher using the generic notify client to implement the ConfigDB-specific endpoints. Probably it will be more appropriate to move the new interface out of this module entirely into a new `rx-client` module; the alternative is to make `rxjs` a mandatory dependency of `service-client`.