### PR TITLE
Support the rx-client extension module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+config.mk
 node_modules
 package-lock.json
 /.idea

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+# Makefile for JS libraries
+
+base=	ghcr.io/amrc-factoryplus/acs-base-js-build:v3.0.0
+
+-include config.mk
+
+all:
+
+.PHONY: all dev
+
+check-committed:
+	[ -z "$$(git status --porcelain)" ] || (git status; exit 1)
+
+lint:
+	npx eslint lib
+
+publish: check-committed lint
+	npm version prerelease
+	npm publish
+
+amend:
+	git commit -C HEAD -a --amend
+
+dev:
+	docker run --rm -ti -v $$(pwd):/local -w /local ${base} /bin/sh
+
+pubdev: check-committed lint
+	sh ./tools/pub-dev.sh "${js.dev_tag}"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,25 @@
+import globals from "globals";
+import js from "@eslint/js";
+
+export default [
+    js.configs.recommended,
+
+    {
+        languageOptions: {
+            globals: {
+                ...globals.node,
+            },
+
+            ecmaVersion: "latest",
+            sourceType: "module",
+        },
+
+        rules: {
+            "no-unreachable": "warn",
+            "no-unused-vars": ["warn", {
+                args:           "none",
+                caughtErrors:   "none",
+            }],
+        },
+    },
+];

--- a/lib/deps.js
+++ b/lib/deps.js
@@ -17,6 +17,7 @@ export const GSS = await import("gssapi.js")
  * 'you can't do `export Foo from "foo"`' then maybe you should design
  * the syntax so you can... ? */
 export { default as MQTT } from "mqtt";
+export { default as WebSocket } from "isomorphic-ws";
 
 export async function build_node_fetch () {
   /* We have to go round the houses a bit here... */

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ export * from "./debug.js";
 export * from "./service-client.js";
 export * from "./service/service-interface.js"
 
+export * as Interfaces from "./interfaces.js";
 export * as UUIDs from "./uuids.js";
 
 export * from "./sparkplug/util.js";

--- a/lib/interfaces.js
+++ b/lib/interfaces.js
@@ -1,0 +1,14 @@
+/*
+ * Factory+ NodeJS Utilities
+ * Service interface exports.
+ * Copyright 2024 University of Sheffield
+ */
+
+export { Auth } from "./service/auth.js";
+export { CmdEsc } from "./service/cmdesc.js";
+export { ConfigDB } from "./service/configdb.js";
+export { Directory } from "./service/directory.js";
+export { Discovery } from "./service/discovery.js";
+export { Fetch } from "./service/fetch.js";
+export { Git } from "./service/git.js";
+export { MQTTInterface } from "./service/mqtt.js";

--- a/lib/service-client.js
+++ b/lib/service-client.js
@@ -7,14 +7,7 @@
 import { Debug } from "./debug.js";
 import { Service } from "./uuids.js";
 
-import Auth from "./service/auth.js";
-import CmdEsc from "./service/cmdesc.js";
-import ConfigDB from "./service/configdb.js";
-import Directory from "./service/directory.js";
-import Discovery from "./service/discovery.js";
-import Fetch from "./service/fetch.js";
-import Git from "./service/git.js";
-import MQTTInterface from "./service/mqtt.js";
+import * as SI from "./interfaces.js";
 
 function opts_from_env (env) {
     const opts = `
@@ -74,13 +67,13 @@ export class ServiceClient {
  * considered backwards-compatible shims. Future service methods will
  * mostly be defined only on the service interface. */
 ServiceClient.define_interfaces(
-    ["Auth", Auth, `check_acl fetch_acl resolve_principal`],
-    ["CmdEsc", CmdEsc, ``],
-    ["ConfigDB", ConfigDB, `fetch_configdb:get_config`],
-    ["Directory", Directory, ``],
-    ["Discovery", Discovery,
+    ["Auth", SI.Auth, `check_acl fetch_acl resolve_principal`],
+    ["CmdEsc", SI.CmdEsc, ``],
+    ["ConfigDB", SI.ConfigDB, `fetch_configdb:get_config`],
+    ["Directory", SI.Directory, ``],
+    ["Discovery", SI.Discovery,
         `set_service_url set_service_discovery service_url service_urls`],
-    ["Fetch", Fetch, `fetch`],
-    ["Git", Git, ``],
-    ["MQTT", MQTTInterface, `mqtt_client`],
+    ["Fetch", SI.Fetch, `fetch`],
+    ["Git", SI.Git, ``],
+    ["MQTT", SI.MQTTInterface, `mqtt_client`],
 );

--- a/lib/service-client.js
+++ b/lib/service-client.js
@@ -5,7 +5,6 @@
  */
 
 import { Debug } from "./debug.js";
-import { Service } from "./uuids.js";
 
 import * as SI from "./interfaces.js";
 

--- a/lib/service/auth.js
+++ b/lib/service/auth.js
@@ -213,7 +213,7 @@ export class Auth extends ServiceInterface {
             body:       spec,
         });
         if (st != 204)
-            this.throw(`Can't ${action} ACE`, st);
+            this.throw(`Can't ${spec.action} ACE`, st);
     }
 
     /* XXX This is a bad API. These should be HTTP methods rather than a

--- a/lib/service/auth.js
+++ b/lib/service/auth.js
@@ -12,7 +12,7 @@ import { App, Service, Null as Null_UUID } from "../uuids.js";
 
 import { ServiceInterface } from "./service-interface.js";
 
-export default class Auth extends ServiceInterface {
+export class Auth extends ServiceInterface {
     constructor (fplus) {
         super(fplus);
 

--- a/lib/service/cmdesc.js
+++ b/lib/service/cmdesc.js
@@ -4,7 +4,6 @@
  * Copyright 2023 AMRC.
  */
 
-import { Address } from "../sparkplug/util.js";
 import { Service } from "../uuids.js";
 
 import { ServiceInterface } from "./service-interface.js";

--- a/lib/service/cmdesc.js
+++ b/lib/service/cmdesc.js
@@ -9,7 +9,7 @@ import { Service } from "../uuids.js";
 
 import { ServiceInterface } from "./service-interface.js";
 
-export default class CmdEsc extends ServiceInterface {
+export class CmdEsc extends ServiceInterface {
     constructor (fplus) {
         super(fplus);
         this.service = Service.Command_Escalation;

--- a/lib/service/configdb.js
+++ b/lib/service/configdb.js
@@ -6,7 +6,7 @@
 
 import { format } from "util";
 
-import { App, Service, Null as Null_UUID } from "../uuids.js";
+import { App, Service } from "../uuids.js";
 
 import { ServiceInterface } from "./service-interface.js";
 

--- a/lib/service/configdb.js
+++ b/lib/service/configdb.js
@@ -10,7 +10,7 @@ import { App, Service, Null as Null_UUID } from "../uuids.js";
 
 import { ServiceInterface } from "./service-interface.js";
 
-export default class ConfigDB extends ServiceInterface {
+export class ConfigDB extends ServiceInterface {
     constructor (fplus) {
         super(fplus);
         this.service = Service.ConfigDB;

--- a/lib/service/directory.js
+++ b/lib/service/directory.js
@@ -5,7 +5,7 @@
  */
 
 import { Address } from "../sparkplug/util.js";
-import { Service, Null as Null_UUID } from "../uuids.js";
+import { Service } from "../uuids.js";
 
 import { ServiceInterface } from "./service-interface.js";
 

--- a/lib/service/directory.js
+++ b/lib/service/directory.js
@@ -9,7 +9,7 @@ import { Service, Null as Null_UUID } from "../uuids.js";
 
 import { ServiceInterface } from "./service-interface.js";
 
-export default class Directory extends ServiceInterface {
+export class Directory extends ServiceInterface {
     constructor (fplus) {
         super(fplus);
         this.service = Service.Directory;

--- a/lib/service/discovery.js
+++ b/lib/service/discovery.js
@@ -8,7 +8,7 @@ import { Service } from "../uuids.js";
 
 import { ServiceInterface } from "./service-interface.js";
 
-export default class Discovery extends ServiceInterface {
+export class Discovery extends ServiceInterface {
     constructor (fplus) {
         super(fplus);
         this.urls = new Map();

--- a/lib/service/fetch.js
+++ b/lib/service/fetch.js
@@ -4,9 +4,9 @@
  * Copyright 2022 AMRC.
  */
 
-import { build_node_fetch, GSS } from "../deps.js";
+import { build_node_fetch, GSS, WebSocket } from "../deps.js";
 
-import { ServiceInterface } from "./service-interface.js";
+import { ServiceError, ServiceInterface } from "./service-interface.js";
 
 const Auth_rx = /^([A-Za-z]+) +([A-Za-z0-9._~+/=-]+)$/;
 
@@ -101,6 +101,58 @@ export class Fetch extends ServiceInterface {
         }
     }
 
+    async websocket (opts) {
+        const base = opts.service_url
+            ?? await this.fplus.service_url(opts.service);
+        const url = new URL(opts.url, base);
+
+        const ws = new WebSocket(url);
+        await new Promise((resolve, reject) => {
+            const errh = e => {
+                const msg = e.type == "error"
+                    ? `WebSocket connection error: ${e.message}`
+                    : "WebSocket connection failed";
+                /* XXX should supply e as cause here */
+                reject(new ServiceError(opts.service, msg));
+            };
+            ws.addEventListener("open", resolve, { once: true });
+            ws.addEventListener("error", errh, { once: true });
+        });
+        return ws;
+    }
+
+    async ws_with_auth (opts) {
+        const base = await this.fplus.service_url(opts.service);
+
+        const try_ws = async bad => {
+            const ws = await this.websocket({ ...opts, service_url: base });
+            const token = await this.service_token(base, bad);
+
+            ws.send(`Bearer ${token}`);
+            const msg = await new Promise((resolve, reject) => {
+                ws.addEventListener("message", resolve, { once: true });
+                ws.addEventListener("error", reject, { once: true });
+            });
+
+            return [ws, msg.data, token];
+        };
+
+        let [ws, st, bad] = await try_ws();
+        if (st == "401")
+            [ws, st] = await try_ws(bad);
+        if (st == "200")
+            return ws;
+        
+        if (typeof st == "string" && /^[0-9]{3}$/.test(st)) {
+            throw new ServiceError(opts.service,
+                "WebSocket auth refused",
+                Number.parseInt(st, 10));
+        }
+
+        throw new ServiceError(opts.service,
+            "Unrecognised WS auth response: %s", st);
+    }
+        
     async do_fetch (url, opts) {
         let token;
         const try_fetch = async () => {

--- a/lib/service/fetch.js
+++ b/lib/service/fetch.js
@@ -62,7 +62,7 @@ function _idempotent (opts) {
     return !opts.body;
 }
 
-export default class Fetch extends ServiceInterface {
+export class Fetch extends ServiceInterface {
     constructor (fplus) {
         super(fplus);
         this.tokens = new Map();

--- a/lib/service/git.js
+++ b/lib/service/git.js
@@ -7,7 +7,7 @@
 /* This interface is a bit minimal, as I don't want to depend on a git
  * library. */
 
-import { App, Service } from "../uuids.js";
+import { Service } from "../uuids.js";
 
 import { ServiceInterface } from "./service-interface.js";
 

--- a/lib/service/git.js
+++ b/lib/service/git.js
@@ -11,7 +11,7 @@ import { App, Service } from "../uuids.js";
 
 import { ServiceInterface } from "./service-interface.js";
 
-export default class Git extends ServiceInterface {
+export class Git extends ServiceInterface {
     constructor (fplus) {
         super(fplus);
 

--- a/lib/service/mqtt.js
+++ b/lib/service/mqtt.js
@@ -138,7 +138,7 @@ async function basic_mqtt(url, opts) {
     return mqtt;
 }
 
-export default class MQTTInterface extends ServiceInterface {
+export class MQTTInterface extends ServiceInterface {
     constructor (fplus) {
         super(fplus);
 

--- a/lib/service/service-interface.js
+++ b/lib/service/service-interface.js
@@ -81,4 +81,12 @@ export class ServiceInterface {
         if (st != 200) return;
         return ping;
     }
+
+    /* This always authenticates the WS */
+    websocket (url) {
+        return this.fplus.Fetch.ws_with_auth({
+            service:    this.service,
+            url,
+        });
+    }
 }

--- a/lib/sparkplug/basic-node.js
+++ b/lib/sparkplug/basic-node.js
@@ -2,7 +2,7 @@ import { EventEmitter } from "events";
 
 import { Debug } from "../debug.js";
 import { SpB } from "../deps.js";
-import { Address, Topic } from "./util.js";
+import { Topic } from "./util.js";
 
 export class BasicSparkplugNode extends EventEmitter {
     constructor (opts) {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "content-type": "^1.0.5",
+    "isomorphic-ws": "^5.0.0",
     "mqtt": "^5.3.6",
     "optional-js": "^2.3.0",
     "semver": "^7.6.0",

--- a/package.json
+++ b/package.json
@@ -20,5 +20,11 @@
   "optionalDependencies": {
     "got-fetch": "^5.1.8",
     "gssapi.js": "^2.0.1"
+  },
+  "devDependencies": {
+    "@eslint/eslintrc": "^3.1.0",
+    "@eslint/js": "^9.13.0",
+    "eslint": "^9.13.0",
+    "globals": "^15.11.0"
   }
 }

--- a/tools/pub-dev.sh
+++ b/tools/pub-dev.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -ex
+
+tag="$1"
+if [ -z "$tag" ]
+then
+    echo "Set js.dev_tag in config.mk!" >&2
+    exit 1
+fi
+
+cp package.json ~package.json~
+sed -e's/"version": .*/"version": "'"$tag"'",/' \
+        < ~package.json~ >package.json
+npm publish
+mv ~package.json~ package.json
+
+ix="${tag##*.}"
+sed -i -re'/^js\.dev_tag=/s/[^.]*$/'"$(( ix + 1 ))"'/' config.mk


### PR DESCRIPTION
Export the service interface classes so they can be inherited from.

Expose a service interface method to open a WebSocket to the service. This also supports authenticating using the protocol I have invented for the `notify/v2` interface; some form of explicit authentication will always be necessary when using the JS WebSocket API.

Admin:
* Remove default exports, they're considered a bad idea.
* Pull in a Makefile with `lint` and `pubdev` actions.
* Run eslint and fix the warnings.