### PR TITLE
Update Basic MQTT Version

### DIFF
--- a/lib/service/mqtt.js
+++ b/lib/service/mqtt.js
@@ -57,8 +57,8 @@ export async function gss_mqtt (url, opts) {
 
     const mqtt = MQTT.connect(url, {
         reconnectPeriod: 3000,
-        ...opts,
         protocolVersion: 5,
+        ...opts,
         properties: {
             ...opts.properties,
             authenticationMethod: "GSSAPI",
@@ -126,8 +126,8 @@ async function basic_mqtt(url, opts) {
 
     verb(`Basic auth with ${opts.username}`);
     const mqtt = MQTT.connect(url,{
-        ...opts,
         protocolVersion: 5,
+        ...opts,
     });
     mqtt.on("connect", ack => {
         verb("MQTT connected");

--- a/lib/service/mqtt.js
+++ b/lib/service/mqtt.js
@@ -126,7 +126,8 @@ async function basic_mqtt(url, opts) {
 
     verb(`Basic auth with ${opts.username}`);
     const mqtt = MQTT.connect(url,{
-        ...opts
+        ...opts,
+        protocolVersion: 5,
     });
     mqtt.on("connect", ack => {
         verb("MQTT connected");


### PR DESCRIPTION
Previously, the Basic MQTT client and GSS MQTT client used different MQTT protocol versions, leading to inconsistency. This update ensures both clients now use the same default MQTT protocol version for uniform behaviour.