### PR TITLE
Bootstrap ACL support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ config.mk
 node_modules
 package-lock.json
 /.idea
+/tmp

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 export * from "./debug.js";
 export * from "./service-client.js";
 export * from "./service/service-interface.js"
+export * from "./well-known.js";
 
 export * as Interfaces from "./interfaces.js";
 export * as UUIDs from "./uuids.js";

--- a/lib/service-client.js
+++ b/lib/service-client.js
@@ -14,6 +14,7 @@ function opts_from_env (env) {
         CONFIGDB_URL
         DIRECTORY_URL
         MQTT_URL
+        BOOTSTRAP_ACL
         ROOT_PRINCIPAL
         SERVICE_USERNAME:username
         SERVICE_PASSWORD:password

--- a/lib/service/auth.js
+++ b/lib/service/auth.js
@@ -8,7 +8,8 @@ import * as semver from "semver";
 
 import { Address } from "../sparkplug/util.js";
 
-import { App, Service, Null as Null_UUID } from "../uuids.js";
+import { App, Service, Null as Null_UUID }  from "../uuids.js";
+import { WellKnown }                        from "../well-known.js";
 
 import { ServiceInterface } from "./service-interface.js";
 
@@ -19,6 +20,38 @@ export class Auth extends ServiceInterface {
         this.service = Service.Authentication;
         this.root_principal = fplus.opts.root_principal;
         this.permission_group = fplus.opts.permission_group;
+
+        this.bootstrap_acl = this._build_bs_acl(fplus.opts);
+    }
+
+    _build_bs_acl (opts) {
+        const { bootstrap_acl, bootstrap_uuids } = opts;
+
+        const wk = new WellKnown({ uuids: bootstrap_uuids ?? {} });
+
+        const acl = new Map();
+        if (!bootstrap_acl) return acl;
+
+        const entries = bootstrap_acl.split("\n")
+            .filter(l => l.length)
+            .map(l => l.split(":"))
+            .map(([princ, perm, targ]) => 
+                [princ, { 
+                    permission:     wk.lookup(perm),
+                    target:         wk.lookup(targ),
+                }]);
+
+        for (const [p, e] of entries) {
+            let l = acl.get(p);
+            if (!l) {
+                l = [];
+                acl.set(p, l);
+            }
+            l.push(e);
+        }
+
+        this.debug.log("acl", "Bootstrap ACL: %o", acl);
+        return acl;
     }
     
     /* Verifies if principal has permission on target. If 'wild' is true
@@ -42,23 +75,20 @@ export class Auth extends ServiceInterface {
                 "Unrecognised principal request: %o", princ_req);
             return () => false;
         }
-        const by_uuid = type == "uuid";
 
         if (this.root_principal 
             && type == "kerberos" 
-            && principal == this.root_principal)
+            && principal == this.root_principal
+        ) {
+            this.debug.log("acl", "Principal %s has root access", principal);
             return () => true;
-
-        const res = await this.fplus.fetch({
-            service:    Service.Authentication,
-            url:        "/authz/acl",
-            query:      { principal, permission: group, "by-uuid": by_uuid },
-        });
-        if (!res.ok) {
-            this.debug.log("acl", `Failed to read ACL for ${principal}: ${res.status}`);
-            return () => false;
         }
-        const acl = await res.json();
+
+        const acl = (type == "kerberos" && this.bootstrap_acl.has(principal))
+            ? this.bootstrap_acl.get(principal)
+            : await this._fetch_acl(principal, group, type == "uuid");
+
+        if (!acl) return () => false;
         this.debug.log("acl", "Got ACL for %s: %o", principal, acl);
 
         return (permission, target, wild) => 
@@ -66,6 +96,19 @@ export class Auth extends ServiceInterface {
                 ace.permission == permission
                 && (ace.target == target
                     || (wild && ace.target == Null_UUID)));
+    }
+
+    async _fetch_acl (principal, group, by_uuid) {
+        const res = await this.fplus.fetch({
+            service:    Service.Authentication,
+            url:        "/authz/acl",
+            query:      { principal, permission: group, "by-uuid": by_uuid },
+        });
+        if (!res.ok) {
+            this.debug.log("acl", `Failed to read ACL for ${principal}: ${res.status}`);
+            return;
+        }
+        return res.json();
     }
 
     /* Resolve a principal to a UUID. Query is an object with a single

--- a/lib/well-known.js
+++ b/lib/well-known.js
@@ -1,0 +1,41 @@
+/*
+ * Factory+ JS ServiceClient
+ * Well-known UUID lookups
+ * Copyright 2025 University of Sheffield AMRC
+ */
+
+import util from "util";
+
+const uuid_rx = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/* grr */
+function bad (str) {
+    throw new Error(util.format("Bad UUID: %s", str));
+}
+
+function u_flat (obj) {
+    const es = obj instanceof Map
+        ? [es.entries()]
+        : Object.entries(obj);
+    return es.flatMap(([k, v]) =>
+        typeof v == "string" ?
+            uuid_rx.test(v) ? [[k, v]]
+            : bad(v)
+        : u_flat(v)
+            .map(([s, v]) => [`${k}.${s}`, v]));
+}
+
+export class WellKnown {
+    constructor (opts) {
+        this.wk = new Map(u_flat(opts.uuids));
+    }
+
+    lookup (str) {
+        if (uuid_rx.test(str))
+            return str;
+        const u = this.wk.get(str);
+        if (u)
+            return u;
+        bad(str);
+    }
+}


### PR DESCRIPTION
* Support a bootstrap ACL parameter to the ServiceClient.
* Provide a class for looking up well-known UUIDs.

The bootstrap ACL support is needed to allow the Auth service to access ConfigDB class membership lists.